### PR TITLE
Clean up repr

### DIFF
--- a/pyrollout/feature/__init__.py
+++ b/pyrollout/feature/__init__.py
@@ -33,16 +33,33 @@ class Feature(object):
 
     def __repr__(self):
         """
-        Nicer representation of this object with semi-readable configuration included.
+        Build Feature representation.
+
+        :returns: str repr: ``eval``-ready string representation of feature.
+        """
+        s = []
+        if self.name:
+            s.append("'%s'" % self.name)
+        for p in ['groups', 'percentage', 'randomize', 'users']:
+            v = getattr(self, p)
+            s.append('%s=%s' % (p, repr(v)))
+        s = ', '.join(s)
+        return 'Feature(%s)' % s
+
+    def __str__(self):
+        """
+        Nicer representation of feature with semi-readable configuration.
+
+        :returns: str str: Human-readable string representation of feature.
         """
         repr_string = '<Feature {NAME} - %s>'.format(NAME=self.name)
         config_string = ''
         if len(self.users) > 0:
-            config_string += 'U:%s ' % self.users
+            config_string += 'Users:%s ' % self.users
         if len(self.groups) > 0:
-            config_string += 'G:%s ' % self.groups
+            config_string += 'Groups:%s ' % self.groups
         if self.percentage != 0:
-            config_string += 'P:{PCT}:{RAND}'.format(
+            config_string += 'Percent:{PCT}:{RAND}'.format(
                 PCT=self.percentage,
                 RAND=self.randomize
             )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -40,10 +40,21 @@ class TestBasicFunctions(unittest.TestCase):
         self.assertTrue(self.rollout.can(user, 'feature_for_all') is True)
 
     def test_repr(self):
-        feature_repr = repr(Feature('ff1', groups=['a'], users=[1], percentage=1))
-        self.assertTrue("G:['a'] " in feature_repr)
-        self.assertTrue("U:[1] " in feature_repr)
-        self.assertTrue("P:1:False>" in feature_repr)
+        feature = Feature('ff1', groups=['a'], users=[1], percentage=1)
+        feature_repr = repr(feature)
+        feature_compare = eval(feature_repr)
+        self.assertEqual(feature.name, feature_compare.name)
+        self.assertEqual(feature.groups, feature_compare.groups)
+        self.assertEqual(feature.percentage, feature_compare.percentage)
+        self.assertEqual(feature.randomize, feature_compare.randomize)
+        self.assertEqual(feature.users, feature_compare.users)
+
+    def test_str(self):
+        feature_str = str(Feature('ff1', groups=['a'], users=[1], percentage=1))
+        print feature_str
+        self.assertTrue("Groups:['a']" in feature_str)
+        self.assertTrue("Users:[1]" in feature_str)
+        self.assertTrue("Percent:1:False" in feature_str)
 
     def test_all(self):
         user = self._add_user()


### PR DESCRIPTION
`__repr__` is supposed to return a string that can be passed to `eval()`. This repairs that issue and adds a `__str__` method that allows for the nicer, human-readable representation of a `Feature`.

The test cases would be cleaner if `__eq__` was implemented. Instead of:

```
self.assertEqual(feature.name, feature_compare.name)
self.assertEqual(feature.groups, feature_compare.groups)
self.assertEqual(feature.percentage, feature_compare.percentage)
self.assertEqual(feature.randomize, feature_compare.randomize)
self.assertEqual(feature.users, feature_compare.users)
```

I could have used:

```
self.assertEqual(feature, feature_compare)
```
