### PR TITLE
Add in a Google AppEngine Storage backend

### DIFF
--- a/pyrollout/storage/gae.py
+++ b/pyrollout/storage/gae.py
@@ -1,0 +1,56 @@
+
+from google.appengine.ext import ndb
+from pyrollout.feature import Feature
+from pyrollout.storage import FeatureStorageManager, UserStorageManager
+
+
+class PyRolloutFeature(ndb.Model):
+    name = ndb.StringField(required=True)
+    groups = ndb.StringField(repeated=True)
+    users = ndb.StringField(repeated=True)
+    percentage = ndb.IntegerField()
+    randomize = ndb.BooleanField(default=False)
+
+    @classmethod
+    def get_by_name(cls, name):
+        return cls.query(cls.name == name).get()
+
+
+class GAEFeatureStorage(FeatureStorageManager):
+
+    def get_feature_config(self, feature_name):
+        feature = PyRolloutFeature.get_by_name(feature_name)
+        if feature:
+            feature = Feature(
+                feature.name,
+                groups=feature.groups,
+                users=feature.users,
+                percentage=feature.percentage,
+                randomize=feature.randomize)
+
+        return feature
+
+    def set_feature_config(self, feature_name, feature_data):
+        feature = PyRolloutFeature.get_by_name(feature_name)
+        if feature:
+            feature.groups = feature_data.groups
+            feature.users = feature_data.users
+            feature.percentage = feature_data.percentage
+            feature.randomize = feature_data.randomize
+        else:
+            feature = PyRolloutFeature(name=feature_data.name,
+                                       groups=feature_data.groups,
+                                       users=feature_data.users,
+                                       percentage=feature_data.percentage,
+                                       randomize=feature_data.randomize)
+        feature.put()
+
+
+class GAEUserStorage(UserStorageManager):
+    """Left unimplemented because every software's implementation of users is different."""
+
+    def get_user_property(self, user, property_name, default_value=None):
+        raise NotImplementedError()
+
+    def add_user(self, user):
+        raise NotImplementedError()

--- a/pyrollout/storage/gae.py
+++ b/pyrollout/storage/gae.py
@@ -5,11 +5,11 @@ from pyrollout.storage import FeatureStorageManager, UserStorageManager
 
 
 class PyRolloutFeature(ndb.Model):
-    name = ndb.StringField(required=True)
-    groups = ndb.StringField(repeated=True)
-    users = ndb.StringField(repeated=True)
-    percentage = ndb.IntegerField()
-    randomize = ndb.BooleanField(default=False)
+    name = ndb.StringProperty(required=True)
+    groups = ndb.StringProperty(repeated=True)
+    users = ndb.GenericProperty(repeated=True)
+    percentage = ndb.IntegerProperty()
+    randomize = ndb.BooleanProperty(default=False)
 
     @classmethod
     def get_by_name(cls, name):


### PR DESCRIPTION
The GAE backend intentionally does not implement a user storage mechanism since there's not a super logical way of doing that. Everybody's application is different. I figure that those people using the AppEngine backend will really implement their own. I didn't write any formal tests for it because of the necessary dependencies around it, though my local and anecdotal tests worked just fine.